### PR TITLE
Add NIP-11 metadata support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::nostr::get_nip11_response;
 pub(crate) use crate::nostr::{
     try_queue_event, NOSTR_QUEUE, NOSTR_QUEUE_2, NOSTR_QUEUE_3, NOSTR_QUEUE_4, NOSTR_QUEUE_5,
     NOSTR_QUEUE_6,
@@ -109,7 +110,14 @@ pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
             empty_response()
         })
-        .get("/", |_, ctx| {
+        .get("/", |req, ctx| {
+            // NIP 11
+            if req.headers().get("Accept").ok().flatten()
+                == Some("application/nostr+json".to_string())
+            {
+                return Response::from_json(&get_nip11_response())?.with_cors(&cors());
+            }
+
             // For websocket compatibility
             let pair = WebSocketPair::new()?;
             let server = pair.server;

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use futures::pin_mut;
 use futures::StreamExt;
 use nostr::prelude::*;
+use std::string::ToString;
 use std::{time::Duration, vec};
 use worker::WebsocketEvent;
 use worker::{console_log, Cache, Delay, Fetch, Queue, Response, WebSocket};
@@ -23,6 +24,23 @@ const RELAYS: [&str; 8] = [
     "wss://relay.damus.io",
     "wss://nostr.wine",
 ];
+
+pub fn get_nip11_response() -> RelayInformationDocument {
+    let version = env!("CARGO_PKG_VERSION");
+    let supported_nips = vec![1, 11, 20];
+
+    RelayInformationDocument {
+        name: Some("Mutiny blastr relay".to_string()),
+        description: Some("Mutiny blastr relay".to_string()),
+        pubkey: Some(
+            "df173277182f3155d37b330211ba1de4a81500c02d195e964f91be774ec96708".to_string(),
+        ),
+        contact: Some("team@mutinywallet.com".to_string()),
+        supported_nips: Some(supported_nips),
+        software: Some("git+https://github.com/MutinyWallet/blastr.git".to_string()),
+        version: Some(version.to_string()),
+    }
+}
 
 pub async fn try_queue_event(event: Event, nostr_queues: Vec<Queue>) {
     for nostr_queue in nostr_queues.iter() {


### PR DESCRIPTION
Returns NIP-11metadata

Can test by running with `npm run dev` then calling it with `curl -X GET http://localhost:8787 -H "Accept: application/nostr+json"`