### PR TITLE
Send EOSE when we receive a subscription

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,15 @@ pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                                             .send_with_str(&relay_msg.as_json())
                                             .expect("failed to send response");
                                     }
+                                    ClientMessage::Req {
+                                        subscription_id, ..
+                                    } => {
+                                        console_log!("ignoring nostr subscription request");
+                                        let relay_msg = RelayMessage::new_eose(subscription_id);
+                                        server
+                                            .send_with_str(&relay_msg.as_json())
+                                            .expect("failed to send response");
+                                    }
                                     _ => {
                                         console_log!("ignoring other nostr client message types");
                                     }

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -28,7 +28,7 @@ const RELAYS: [&str; 8] = [
 
 pub fn get_nip11_response() -> RelayInformationDocument {
     let version = env!("CARGO_PKG_VERSION");
-    let supported_nips = vec![1, 11, 20];
+    let supported_nips = vec![1, 11, 15, 20];
 
     RelayInformationDocument {
         name: Some("Mutiny blastr relay".to_string()),


### PR DESCRIPTION
This will signal to clients that we dont have any events for them, this should make clients that are just requesting events disconnect from us sooner or on their own.

https://github.com/nostr-protocol/nips/blob/master/15.md