### PR TITLE
Store Nostr Wallet Connect Events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["console_error_panic_hook"]
 cfg-if = "0.1.2"
 worker = {  version = "0.0.13", features = ["queue"] }
 futures = "0.3.26"
-nostr = { version = "0.19.5", default-features = false, features = ["nip11"] }
+nostr = { version = "0.22.0", default-features = false, features = ["nip11"] }
 serde = { version = "^1.0", features = ["derive"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ Right now some of these are hardcoded for us since they have to map from the `wr
 
 This doesn't rebroadcast events that have already been broadcasted before. So we have a KV for that.
 
+We also have a KV for storing the NWC requests and responses to get around ephemeral events.
+
 ```
 wrangler kv:namespace create PUBLISHED_NOTES
 wrangler kv:namespace create PUBLISHED_NOTES --preview
+
+wrangler kv:namespace create NWC_REQUESTS
+wrangler kv:namespace create NWC_REQUESTS --preview
+
+wrangler kv:namespace create NWC_RESPONSES
+wrangler kv:namespace create NWC_RESPONSES --preview
 ```
 
 #### Queues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@ pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                                                 .expect("failed to send response");
                                         }
 
-                                        console_log!("ignoring nostr subscription request");
+                                        console_log!("end of subscription request");
                                         let relay_msg = RelayMessage::new_eose(subscription_id);
                                         server
                                             .send_with_str(&relay_msg.as_json())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                                             }
                                         }
 
-                                        // send all found evens to the user
+                                        // send all found events to the user
                                         for event in events {
                                             console_log!("sending event to client: {}", &event.id);
                                             let relay_msg = RelayMessage::new_event(

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,7 +12,9 @@ routes = [
 # create the queues with `wrangler kv:namespace create PUBLISHED_NOTES` and the same command with the `--preview` flag.
 # put your queue IDs below
 kv_namespaces = [
-  { binding = "PUBLISHED_NOTES", id = "afa24a392a5a41f6b1655507dfd9b97a", preview_id = "0b334aece8d74c3ab90e3e99db569ce8" }
+  { binding = "PUBLISHED_NOTES", id = "afa24a392a5a41f6b1655507dfd9b97a", preview_id = "0b334aece8d74c3ab90e3e99db569ce8" },
+  { binding = "NWC_REQUESTS", id = "e5bd788ddc16410bb108df0f2ae89e62", preview_id = "63d99f551a464ff78bbbbee7113cb658" },
+  { binding = "NWC_RESPONSES", id = "5b434d5eced84abaad1c9a44448ac71c", preview_id = "af27b55b58754562b4250dcd3682547b" },
 ]
 
 [vars]


### PR DESCRIPTION
This makes blastr store nostr wallet connect events so we can use them without having to worry about them being epheremeral.