### PR TITLE
[UPDATE] Update nostr.rs to delete eden.nostr.land payment relay

### DIFF
--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -23,7 +23,6 @@ const RELAY_LIST_URL: &str = "https://api.nostr.watch/v1/online";
 const RELAYS: [&str; 8] = [
     "wss://nostr.zebedee.cloud",
     "wss://relay.snort.social",
-    "wss://eden.nostr.land",
     "wss://nos.lol",
     "wss://brb.io",
     "wss://nostr.fmt.wiz.biz",


### PR DESCRIPTION
Remove the connection to eden.nostr.land to publish events because is a payment relay with no public access to write events

Src:
https://relay.exchange/
https://eden.nostr.land/invoices

![imagen](https://github.com/MutinyWallet/blastr/assets/89636253/9381a9a6-0ce4-4ed3-b5a4-de9bd5e052e0)

![imagen](https://github.com/MutinyWallet/blastr/assets/89636253/8ed3b1ca-f164-4479-9d8b-77cced727fff)